### PR TITLE
Make the layout full width, and two columns

### DIFF
--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -1,5 +1,30 @@
-main img {
-  margin-top: 10px;
+body {
   max-width: 100%;
-  border-radius: .375rem;
+  padding: 0;
+}
+main {
+  padding: 0 10px;
+
+  .container {
+    display: flex;
+    max-width: 1024px;
+    margin: 0 auto;
+  }
+  .news {
+    flex: 3 600px;
+  }
+  .calendar {
+    flex: 1 200px;
+  }
+  img {
+    margin: 10px auto 0 auto;
+    width: 800px;
+    display: block;
+    border-radius: .375rem;
+  }
+}
+footer {
+  text-align: center;
+  background-color: var(--color-black);
+  color: var(--color-white);
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,5 +37,8 @@
       </div>
       <%= yield %>
     </main>
+    <footer>
+      &copy; Castlebar A.C. 2024
+    </footer>
   </body>
 </html>

--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -1,19 +1,27 @@
 <%= image_tag("castlebarac.jpg") %>
-<%- if @posts %>
-  <%- @posts.each do |post| %>
-    <h2><%= post.title %></h2>
-    <p><%= post.content %></p>
-    <hr>
-  <%- end %>
-<%- else %>
-  <h1>New website coming soon...</h1>
-  <%- if Flipper.enabled?(:mailing_list) %>
-    <h2>Do you want to know when we launch?</h2>
-    <p>Add your email address here and we'll let you know when to come back</p>
-    <%= form_with model: @mailing_list do |form| %>
-      <%= form.label :address, "Your email address: " %>
-      <%= form.email_field :address, placeholder: "You@your-email.address" %>
-      <%= form.submit "Join the mailing list" %>
+<div class="container">
+  <section class="news">
+    <%- if @posts %>
+      <%- @posts.each do |post| %>
+        <article>
+        <h2><%= post.title %></h2>
+        <p><%= post.content %></p>
+        </article>
+      <%- end %>
+    <%- else %>
+      <h1>New website coming soon...</h1>
+      <%- if Flipper.enabled?(:mailing_list) %>
+        <h2>Do you want to know when we launch?</h2>
+        <p>Add your email address here and we'll let you know when to come back</p>
+        <%= form_with model: @mailing_list do |form| %>
+          <%= form.label :address, "Your email address: " %>
+          <%= form.email_field :address, placeholder: "You@your-email.address" %>
+          <%= form.submit "Join the mailing list" %>
+        <% end %>
+      <% end %>
     <% end %>
-  <% end %>
-<% end %>
+  </section>
+  <section class="calendar">
+    <p>There are no entries yet</p>
+  </section>
+</div>


### PR DESCRIPTION
In preparation for adding in events, I've added a second column to the main part of the page. I also made the layout full width because I kinda prefer that.

News and events will have a max width of 1024 px and are centred in the viewport

<img width="1512" alt="Screenshot 2024-09-13 at 19 17 02" src="https://github.com/user-attachments/assets/51088ac0-3f1f-460d-8b82-57afdb9240da">
