### PR TITLE
Link a result to a person already in the system

### DIFF
--- a/app/controllers/admin/results_controller.rb
+++ b/app/controllers/admin/results_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Admin
+  class ResultsController < ApplicationController
+    def edit
+      @result = Result.find(params[:id])
+      authorize [:admin, @result]
+    end
+
+    def update
+      @result = Result.find(params[:id])
+      authorize [:admin, @result]
+
+      unless (person = Person.find(params[:result][:person_id]))
+        redirect_to event_path(@result.race.event),
+                    notice: "#{params[:result][:person]} wasn't found"
+        return
+      end
+
+      if @result.update(person: person)
+        redirect_to event_path(@result.race.event), notice: "Linked result to #{person.fullname}", status: :see_other
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class PeopleController < ApplicationController
+  def show
+    @person = Person.find_by(slug: params[:id])
+    authorize @person
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -4,6 +4,7 @@ class Person < ApplicationRecord
   belongs_to :user, optional: true
   has_many :memberships, dependent: :destroy
   has_many :teams, through: :memberships
+  has_many :results, dependent: :nullify
 
   before_validation :create_slug
 
@@ -19,6 +20,10 @@ class Person < ApplicationRecord
                 .gsub(/^-/, "")      # remove leading -
                 .gsub(/-$/, "")      # remove trailing -
                 .downcase
+  end
+
+  def to_param
+    slug
   end
 
   def fullname

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -2,7 +2,7 @@
 
 class Result < ApplicationRecord
   belongs_to :race
-  belongs_to :user, optional: true
+  belongs_to :person, optional: true
 
   def net_time
     h = seconds.to_i / 3600

--- a/app/policies/admin/result_policy.rb
+++ b/app/policies/admin/result_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Admin
+  class ResultPolicy < ApplicationPolicy
+    def edit?
+      user&.teams&.exists?(name: "Admins")
+    end
+
+    def update?
+      user&.teams&.exists?(name: "Admins")
+    end
+  end
+end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PersonPolicy < ApplicationPolicy
+  def show?
+    user
+  end
+end

--- a/app/policies/result_policy.rb
+++ b/app/policies/result_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ResultPolicy < ApplicationPolicy
+  def view_person?
+    user
+  end
+end

--- a/app/views/admin/results/_form.html.erb
+++ b/app/views/admin/results/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with model: [:admin, result],
+  data: {
+    controller: "autocomplete",
+    autocomplete_url_value:  people_search_index_url
+  } do |form| %>
+  <div class="auto">
+  <%= form.label :person, "Link this result to: " %>
+  <%= form.text_field :person,
+    required: true,
+    autofocus: true,
+    autocomplete: "off",
+    value: result.person.fullname,
+    data: {
+      autocomplete_target: "input"
+    } %>
+  <%= form.hidden_field :person_id, data: { autocomplete_target: "hidden" } %>
+  <%= form.hidden_field :id, value: result.id %>
+  <ul class="autocomplete" data-autocomplete-target="results"></ul>
+  </div>
+  <%= form.submit "Link them" %>
+<% end %>

--- a/app/views/admin/results/edit.html.erb
+++ b/app/views/admin/results/edit.html.erb
@@ -1,0 +1,42 @@
+<div class="content">
+  <h1>Link someone to this result</h1>
+      <table class="results">
+        <tr>
+          <th>Position</th>
+          <th>Bib</th>
+          <th>Name</th>
+          <th>Linked to</th>
+          <th>Club</th>
+          <th>Category</th>
+          <th>Time</th>
+        </tr>
+          <tr class=cbac">
+            <td class="position">
+              <%= @result.position %>
+            </td>
+            <td class="bib">
+              <%= @result.bib %>
+            </td>
+            <td class="name">
+              <%= @result.name %>
+            </td>
+            <td class="name">
+              <%= link_to @result.person.fullname, person_path(@result.person) %>
+            </td>
+            <td class="club">
+              <%= @result.club %>
+            </td>
+            <td class="category">
+              <%= @result.category %>
+            </td>
+            <td class="result">
+              <%- if ["DNS", "DNF", "DQ", ""].include? @result.result %>
+                <%= @result.result %>
+              <%- else %>
+                <%= @result.net_time %>
+              <%- end %>
+            </td>
+          </tr>
+      </table>
+  <%= render "form", result: @result %>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -19,13 +19,23 @@
         <%- race.results.each do |result| %>
           <tr<%= " class=cbac" if result.club == "Castlebar A.C." %>>
             <td class="position">
+              <%= tag.a(name: dom_id(result)) if result.club == "Castlebar A.C." %>
               <%= result.position %>
             </td>
             <td class="bib">
               <%= result.bib %>
             </td>
             <td class="name">
-              <%= result.name %>
+              <%- if policy([:admin, result]).edit? %>
+                <%= link_to edit_admin_result_path(result) do
+                  inline_svg_tag "pencil.svg"
+                end %>
+              <%- end %>
+              <%- if policy(result).view_person? %>
+                <%= link_to result.name, person_path(result.person) %>
+              <%- else %>
+                <%= result.name %>
+              <%- end %>
             </td>
             <td class="club">
               <%= result.club %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,0 +1,8 @@
+<div class="content">
+  <h2><%= @person.fullname %></h2>
+  <ul>
+  <%- @person.results.each do |result| %>
+    <li><%= result.race.name %> at <%= result.race.event.title %></li>
+  <%- end %>
+  </ul>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
 
   resource :profile
 
+  resources :people, only: :show
   namespace :people do
     resources :search, only: :index
   end
@@ -25,6 +26,7 @@ Rails.application.routes.draw do
     resources :users, only: %i[index update]
     resources :people
     resources :events
+    resources :results, only: %i[edit update]
     resources :posts
     resources :teams
     resources :memberships, only: %i[new create]


### PR DESCRIPTION
Allow an admin to link a castlebar ac athlete in results to an existing person in the system. Use the same autocomplete drop down as the one for adding members to a team to select the person. Once they're selected, link their name to the person so that anyone logged in can see all of their races in one place. This is the start of a personal profile page where you can track your PBs and race history