### PR TITLE
Adjust comments, add policies for events and posts

### DIFF
--- a/app/assets/stylesheets/config/_media.scss
+++ b/app/assets/stylesheets/config/_media.scss
@@ -1,5 +1,6 @@
 @media (prefers-color-scheme: light) {
   :root {
+    --background-body: #fff;
     --background: #efefef;
     --button-base: #d0cfcf;
     --button-hover: #9b9b9b;

--- a/app/assets/stylesheets/config/_media.scss
+++ b/app/assets/stylesheets/config/_media.scss
@@ -8,6 +8,7 @@
     --color-header-bg: hsl(115, 40%, 35%);
     --color-header-border: hsl(115, 40%, 15%);
     --links: #0076d1;
+    --text-muted: #70777f;
     --banner-info-fg: #055160;
     --banner-info-bg: #cff4fc;
     --banner-info-border: #9eeaf9;

--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -63,6 +63,9 @@ article {
     margin: 0;
   }
 }
+.comment {
+  padding-bottom: 5px;
+}
 .subtle {
   color: var(--text-muted);
   font-size: 0.7em;
@@ -79,6 +82,27 @@ input[type="text"] {
   width: 100%;
   padding: 10px;
   transition: border-color 0.3s ease;
+}
+textarea {
+  color: #1d1d1d;
+  color: var(--form-text);
+  background-color: #efefef;
+  background-color: var(--background);
+  font-family: inherit;
+  font-size: inherit;
+  margin-right: 6px;
+  margin-bottom: 6px;
+  padding: 10px;
+  border: none;
+  border-radius: 6px;
+  outline: none;
+}
+textarea:not([cols]) {
+  width: 100%;
+}
+textarea:not([rows]) {
+  min-height: 40px;
+  height: 140px;
 }
 ul.autocomplete {
   position: absolute;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,4 +13,42 @@ class EventsController < ApplicationController
   def show
     @event = Event.find_by(url: params[:id])
   end
+
+  def new
+    @event = Event.new
+    authorize @event
+  end
+
+  def edit
+    @event = Event.find_by(url: params[:id])
+    authorize @event
+  end
+
+  def create
+    @event = Event.new(event_params)
+    authorize @event
+
+    if @event.save
+      redirect_to event_path(@event), notice: "Added #{@event.title}"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @event = Event.find_by(url: params[:id])
+    authorize @event
+
+    if @event.update(event_params)
+      redirect_to event_path(@event), notice: "Updated #{@event.title}"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def event_params
+    params.expect(event: %i[title start_time content])
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,4 +8,39 @@ class PostsController < ApplicationController
   def show
     @post = Post.find_by(url: params[:id])
   end
+
+  def new
+    @post = Post.new
+  end
+
+  def edit
+    @post = Post.find_by(url: params[:id])
+  end
+
+  def create
+    @post = Post.new(post_params)
+    @post.user = current_user
+
+    if @post.save
+      redirect_to post_path(@post), notice: "Added #{@post.title}"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @post = Post.find_by(url: params[:id])
+
+    if @post.update(post_params)
+      redirect_to post_path(@post), notice: "Updated #{@post.title}"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def post_params
+    params.expect(post: %i[title content])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,4 +18,12 @@ class User < ApplicationRecord
   def admin?
     teams.exists?(name: "Admins")
   end
+
+  def coach?
+    teams.exists?(name: "Coaches")
+  end
+
+  def committee?
+    teams.exists?(name: "Committee")
+  end
 end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -10,10 +10,10 @@ class EventPolicy < ApplicationPolicy
   end
 
   def create?
-    user.admin? || user.coach?
+    user.admin? || user.coach? || user.committee?
   end
 
   def update?
-    user.admin? || user.coach?
+    user.admin? || user.coach? || user.committee?
   end
 end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -10,10 +10,14 @@ class EventPolicy < ApplicationPolicy
   end
 
   def create?
+    return false unless user
+
     user.admin? || user.coach? || user.committee?
   end
 
   def update?
+    return false unless user
+
     user.admin? || user.coach? || user.committee?
   end
 end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class EventPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    user.admin? || user.coach?
+  end
+
+  def update?
+    user.admin? || user.coach?
+  end
+end

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class PostPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    user.admin? || user.committee?
+  end
+
+  def update?
+    user.admin? || user.committee?
+  end
+end

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -10,10 +10,14 @@ class PostPolicy < ApplicationPolicy
   end
 
   def create?
+    return false unless user
+
     user.admin? || user.committee?
   end
 
   def update?
+    return false unless user
+
     user.admin? || user.committee?
   end
 end

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,6 +1,6 @@
-<h3>Comments</h3>
+<h3><%= pluralize(commentable.comments.count, "comment")%></h3>
 <%- commentable.comments.each do |comment| %>
-  <div class="well">
+  <div class="comment">
     <%= comment.body %>
     <div class="subtle"><%= time_ago_in_words(comment.created_at) %> ago by <%= comment.user.name %></div>
   </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_for [commentable, Comment.new] do |form| %>
   <%= form.textarea :body, placeholder: "Add a comment" %>
 
-  <%= form.submit "Post" %>
+  <%= form.submit "Comment" %>
 <%- end %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with model: event do |form| %>
+  <%= form.label :title, "Title: " %>
+  <%= form.text_field :title, required: true, autofocus: true, placeholder: "Event title", size: "60" %>
+
+  <%= form.label :start_time, "Date and time: " %>
+  <%= form.datetime_local_field :start_time %>
+
+  <%= form.label :content, "Body: " %>
+  <%= form.hidden_field :content, id: form.field_id(:content), value: form.object.content.try(:to_trix_html) || form.object.content %>
+  <rhino-editor
+    input="<%= form.field_id(:content) %>"
+    data-blob-url-template="<%= rails_service_blob_url(":signed_id", ":filename") %>"
+    data-direct-upload-url="<%= rails_direct_uploads_url %>"
+  ></rhino-editor>
+
+  <%= form.submit "Save" %>
+<% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="content">
+  <h1>Edit event</h1>
+  <%= render "form", event: @event %>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,4 +1,8 @@
+<%- content_for :title, "Events" %>
 <div class="content event-list">
+  <%- if policy(Event.new).new? %>
+    <%= link_to "Add an event", new_event_path %>
+  <%- end %>
   <h2>Upcoming Events</h2>
   <%- if @future_events.empty? %>
     <p>There's nothing planned</p>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,4 @@
+<div class="content">
+  <h1>Create a new event</h1>
+  <%= render "form", event: @event %>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,4 +1,7 @@
 <div class="content">
+  <%- if policy(@event).update? %>
+    <%= link_to "Update event", edit_event_path %>
+  <%- end %>
   <h2><%= @event.title %></h2>
   <p class="subtle"><%= @event.start_time.strftime("%A %e %B %Y at %l:%M%P") %></p>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_with model: post do |form| %>
+  <%= form.label :title, "Title: " %>
+  <%= form.text_field :title, required: true, autofocus: true, placeholder: "Post title" %>
+
+  <%= form.label :content, "Body: " %>
+  <%= form.hidden_field :content, id: form.field_id(:content), value: form.object.content.try(:to_trix_html) || form.object.content %>
+  <rhino-editor
+    input="<%= form.field_id(:content) %>"
+    data-blob-url-template="<%= rails_service_blob_url(":signed_id", ":filename") %>"
+    data-direct-upload-url="<%= rails_direct_uploads_url %>"
+  ></rhino-editor>
+
+  <%= form.submit "Post it" %>
+<% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="content">
+  <h1>Edit post</h1>
+  <%= render "form", post: @post %>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,8 @@
 <%- content_for :title, "News" %>
 <div class="content">
+  <%- if policy(Post.new).new? %>
+    <%= link_to "Add a post", new_post_path %>
+  <%- end %>
   <%- if @posts.empty? %>
     <p>There are no posts</p>
   <%- else %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,4 @@
+<div class="content">
+  <h1>Create a new post</h1>
+  <%= render "form", post: @post %>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,7 @@
 <article class="content">
+  <%- if policy(@post).update? %>
+    <%= link_to "Update post", edit_post_path %>
+  <%- end %>
   <h1><%= @post.title %></h1>
   <div class="subtle"><%= @post.created_at.strftime("%b %-d, %Y") %></div>
   <%= @post.content %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,10 +15,10 @@ Rails.application.routes.draw do
   end
   resources :people, only: :show
 
-  resources :posts, only: %i[index show] do
+  resources :posts, except: :destroy do
     resources :comments, module: :posts
   end
-  resources :events, only: %i[index show]
+  resources :events, except: :destroy
 
   namespace :admin do
     root to: "admin#index"


### PR DESCRIPTION
Make comments look a little better:

<img width="848" alt="Screenshot 2025-06-24 at 23 31 09" src="https://github.com/user-attachments/assets/6eda8e97-7f2e-4605-83ca-e4e177032a59" />

Add policies to allow coaches and committee members to add and edit events, and committee members to add and edit posts. This meant moving the view files from the admin namespace, I'll remove them completely from there in a later PR