### PR TITLE
Add a way to link parents and children

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -48,7 +48,7 @@ module Admin
 
     # Use callbacks to share common setup or constraints between actions.
     def set_person
-      @person = Person.find(params[:id])
+      @person = Person.find_by(slug: params[:id])
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/person_relationships_controller.rb
+++ b/app/controllers/person_relationships_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class PersonRelationshipsController < ApplicationController
+  def create
+    if (person_relationship = PersonRelationship.find_by(person_relationship_params))
+      redirect_to admin_people_path(person.relationship.parent),
+        notice: "already linked"
+      return
+    end
+
+    person_relationship = PersonRelationship.new(person_relationship_params)
+
+    if person_relationship.save
+      redirect_to admin_people_path(person_relationship.parent),
+        notice: "Linked"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def person_relationship_params
+    params.expect(person_relationship: %i[parent_id child_id])
+  end
+end

--- a/app/controllers/person_relationships_controller.rb
+++ b/app/controllers/person_relationships_controller.rb
@@ -2,9 +2,9 @@
 
 class PersonRelationshipsController < ApplicationController
   def create
-    if (person_relationship = PersonRelationship.find_by(person_relationship_params))
+    if PersonRelationship.find_by(person_relationship_params)
       redirect_to admin_people_path(person.relationship.parent),
-        notice: "already linked"
+                  notice: t(".already_done")
       return
     end
 
@@ -12,7 +12,7 @@ class PersonRelationshipsController < ApplicationController
 
     if person_relationship.save
       redirect_to admin_people_path(person_relationship.parent),
-        notice: "Linked"
+                  notice: t(".good")
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,6 +5,21 @@ class Person < ApplicationRecord
   has_many :memberships, dependent: :destroy
   has_many :teams, through: :memberships
   has_many :results, dependent: :nullify
+  has_many :parent_child_relationships,
+    class_name: "PersonRelationship",
+    foreign_key: :child_id,
+    dependent: :destroy
+  has_many :parents,
+    through: :parent_child_relationships,
+    source: :parent
+
+  has_many :child_parent_relationships,
+    class_name: "PersonRelationship",
+    foreign_key: :parent_id,
+    dependent: :destroy
+  has_many :children,
+    through: :child_parent_relationships,
+    source: :child
 
   before_validation :create_slug
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -6,20 +6,22 @@ class Person < ApplicationRecord
   has_many :teams, through: :memberships
   has_many :results, dependent: :nullify
   has_many :parent_child_relationships,
-    class_name: "PersonRelationship",
-    foreign_key: :child_id,
-    dependent: :destroy
+           class_name: "PersonRelationship",
+           foreign_key: :child_id,
+           inverse_of: :parent,
+           dependent: :destroy
   has_many :parents,
-    through: :parent_child_relationships,
-    source: :parent
+           through: :parent_child_relationships,
+           source: :parent
 
   has_many :child_parent_relationships,
-    class_name: "PersonRelationship",
-    foreign_key: :parent_id,
-    dependent: :destroy
+           class_name: "PersonRelationship",
+           foreign_key: :parent_id,
+           inverse_of: :child,
+           dependent: :destroy
   has_many :children,
-    through: :child_parent_relationships,
-    source: :child
+           through: :child_parent_relationships,
+           source: :child
 
   before_validation :create_slug
 

--- a/app/models/person_relationship.rb
+++ b/app/models/person_relationship.rb
@@ -2,7 +2,7 @@
 
 class PersonRelationship < ApplicationRecord
   belongs_to :parent,
-    class_name: "Person"
+             class_name: "Person"
   belongs_to :child,
-    class_name: "Person"
+             class_name: "Person"
 end

--- a/app/models/person_relationship.rb
+++ b/app/models/person_relationship.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class PersonRelationship < ApplicationRecord
+  belongs_to :parent,
+    class_name: "Person"
+  belongs_to :child,
+    class_name: "Person"
+end

--- a/app/policies/person_relationship_policy.rb
+++ b/app/policies/person_relationship_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class PersonRelationshipPolicy < ApplicationPolicy
+  def show?
+    return false unless user
+
+    user.admin? || user.coach? || user.committee?
+  end
+
+  def create?
+    return false unless user
+
+    user.admin? || user.coach? || user.committee?
+  end
+end

--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -2,4 +2,5 @@
   <h1>Editing person</h1>
 
   <%= render "form", person: @person %>
+  <%= render partial: "person_relationships/form", locals: { person_relationship: PersonRelationship.new, parent: @person } %>
 </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,5 +1,13 @@
 <div class="content">
   <h2><%= @person.fullname %></h2>
+  <%- if policy(PersonRelationship.new).show? %>
+    <%- if @person.children.any? %>
+      Parent of <%= @person.children.map(&:fullname).to_sentence %>
+    <%- end %>
+    <%- if @person.parents.any? %>
+      Child of <%= @person.parents.map(&:fullname).to_sentence %>
+    <%- end %>
+  <%- end %>
   <ul>
     <%- @person.results.group_by(&:distance).each do |distance,results| %>
       <h3><%= distance_to_human(distance) %></h3>

--- a/app/views/person_relationships/_form.html.erb
+++ b/app/views/person_relationships/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_with model: person_relationship,
+  data: {
+    controller: "autocomplete",
+    autocomplete_url_value:  people_search_index_url
+  } do |form| %>
+  <div class="auto">
+  <%= form.label :child, "Link someone to their parent" %>
+  <%= form.text_field :child,
+    required: true,
+    autofocus: true,
+    autocomplete: "off",
+    data: {
+      autocomplete_target: "input"
+    } %>
+  <%= form.hidden_field :child_id, data: { autocomplete_target: "hidden" } %>
+  <%= form.hidden_field :parent_id, value: parent.id %>
+  <ul class="autocomplete" data-autocomplete-target="results"></ul>
+  </div>
+  <%= form.submit "Link them" %>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,4 +17,11 @@
       </tr>
     </tbody>
   </table>
+  <%- unless @profile.children.empty? %>
+    <ul>
+      <%- @profile.children.each do |child| %>
+        <li><%= link_to child.fullname, person_path(child) %></li>
+      <%- end %>
+    </ul>
+  <%- end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,3 +47,7 @@ en:
   comments:
     create:
       notice: "Your comment was successfully posted"
+  person_relationships:
+    create:
+      already_done: "already linked"
+      good: "Linked"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     resources :search, only: :index
   end
   resources :people, only: :show
+  resources :person_relationships, only: :create
 
   resources :posts, except: :destroy do
     resources :comments, module: :posts

--- a/db/migrate/20250625212525_create_person_relationships_join_table.rb
+++ b/db/migrate/20250625212525_create_person_relationships_join_table.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreatePersonRelationshipsJoinTable < ActiveRecord::Migration[8.0]
+  def change
+    create_table "person_relationships", force: true do |t|
+      t.integer  "parent_id"
+      t.integer  "child_id"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_25_134906) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_25_212525) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -105,6 +105,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_25_134906) do
     t.datetime "updated_at", null: false
     t.string "slug"
     t.index ["user_id"], name: "index_people_on_user_id"
+  end
+
+  create_table "person_relationships", force: :cascade do |t|
+    t.integer "parent_id"
+    t.integer "child_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "posts", force: :cascade do |t|


### PR DESCRIPTION
This is a biggie.

Parents want to see how their kids are doing, so there should be a way to link them and allow parents to view the results of their kids in an easy way. This also allows coaches and committee members to quickly see who's a parent of who.

Linking people is a manual process at the moment, but with some luck it won't be too onerous to do it.

https://stackoverflow.com/questions/8136231/self-referential-has-many-through-in-rails and https://dev.to/sulmanweb/rails-self-join-tables-parent-child-magic-5abg were two useful articles to read through to figure out how to do this