### PR TITLE
Add database tables for coach posts and friendly_id

### DIFF
--- a/db/migrate/20260429220653_create_coach_posts.rb
+++ b/db/migrate/20260429220653_create_coach_posts.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateCoachPosts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :coach_posts do |t|
+      t.string :title, null: false, limit: 256
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260430210948_add_slug_to_coach_posts.rb
+++ b/db/migrate/20260430210948_add_slug_to_coach_posts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSlugToCoachPosts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :coach_posts, :slug, :string
+    add_index :coach_posts, :slug, unique: true
+  end
+end

--- a/db/migrate/20260430211003_create_friendly_id_slugs.rb
+++ b/db/migrate/20260430211003_create_friendly_id_slugs.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+MIGRATION_CLASS =
+  if ActiveRecord::VERSION::MAJOR >= 5
+    ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+  else
+    ActiveRecord::Migration
+  end
+
+class CreateFriendlyIdSlugs < MIGRATION_CLASS
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string :slug, null: false
+      t.integer :sluggable_id, null: false
+      t.string :sluggable_type, limit: 50
+      t.string :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, %i[sluggable_type sluggable_id]
+    add_index :friendly_id_slugs, %i[slug sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, %i[slug sluggable_type scope], length: { slug: 70, sluggable_type: 50, scope: 70 },
+                                                                 unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,36 +10,36 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_19_213139) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_30_211003) do
   create_table "action_text_rich_texts", force: :cascade do |t|
-    t.string "name", null: false
     t.text "body"
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.datetime "updated_at", null: false
     t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum"
+    t.string "content_type"
     t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -49,52 +49,62 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_19_213139) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "comments", force: :cascade do |t|
-    t.string "commentable_type"
-    t.integer "commentable_id"
+  create_table "coach_posts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "slug"
+    t.string "title", limit: 256, null: false
+    t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.index ["slug"], name: "index_coach_posts_on_slug", unique: true
+    t.index ["user_id"], name: "index_coach_posts_on_user_id"
+  end
+
+  create_table "comments", force: :cascade do |t|
     t.text "body"
+    t.integer "commentable_id"
+    t.string "commentable_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
   end
 
   create_table "events", force: :cascade do |t|
-    t.string "title", limit: 256, null: false
-    t.datetime "start_time", null: false
     t.datetime "created_at", null: false
+    t.datetime "start_time", null: false
+    t.string "title", limit: 256, null: false
     t.datetime "updated_at", null: false
     t.string "url"
   end
 
   create_table "flipper_features", force: :cascade do |t|
-    t.string "key", null: false
     t.datetime "created_at", null: false
+    t.string "key", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
   create_table "flipper_gates", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.string "feature_key", null: false
     t.string "key", null: false
-    t.text "value"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "value"
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "forums", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.string "name", limit: 256, null: false
     t.string "slug", limit: 256, null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|
+    t.datetime "created_at"
+    t.string "scope"
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
-    t.string "scope"
-    t.datetime "created_at"
     t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
     t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
@@ -107,186 +117,186 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_19_213139) do
   end
 
   create_table "memberships", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.integer "person_id"
     t.integer "team_id"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["person_id"], name: "index_memberships_on_person_id"
     t.index ["team_id"], name: "index_memberships_on_team_id"
   end
 
   create_table "messages", force: :cascade do |t|
-    t.integer "topic_id"
-    t.integer "user_id"
-    t.integer "parent_id"
     t.datetime "created_at", null: false
+    t.integer "parent_id"
+    t.integer "topic_id"
     t.datetime "updated_at", null: false
+    t.integer "user_id"
     t.index ["parent_id"], name: "index_messages_on_parent_id"
     t.index ["topic_id"], name: "index_messages_on_topic_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
   create_table "people", force: :cascade do |t|
-    t.string "firstname", limit: 256, null: false
-    t.string "surname", limit: 256, null: false
-    t.integer "user_id"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "slug"
-    t.string "year"
+    t.string "firstname", limit: 256, null: false
     t.string "gender"
+    t.string "slug"
+    t.string "surname", limit: 256, null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.string "year"
     t.index ["user_id"], name: "index_people_on_user_id"
   end
 
   create_table "person_relationships", force: :cascade do |t|
-    t.integer "parent_id"
     t.integer "child_id"
     t.datetime "created_at", null: false
+    t.integer "parent_id"
     t.datetime "updated_at", null: false
   end
 
   create_table "posts", force: :cascade do |t|
-    t.string "title", limit: 256, null: false
-    t.integer "user_id"
     t.datetime "created_at", null: false
+    t.string "title", limit: 256, null: false
     t.datetime "updated_at", null: false
     t.string "url"
+    t.integer "user_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "races", force: :cascade do |t|
-    t.string "name"
-    t.integer "event_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "category"
+    t.datetime "created_at", null: false
+    t.integer "event_id", null: false
+    t.string "name"
+    t.datetime "updated_at", null: false
     t.index ["event_id"], name: "index_races_on_event_id"
   end
 
   create_table "results", force: :cascade do |t|
-    t.string "name"
-    t.string "club"
-    t.decimal "seconds"
-    t.integer "heat"
     t.integer "bib"
     t.string "category"
-    t.integer "race_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "result"
-    t.integer "position"
-    t.integer "person_id"
-    t.integer "distance"
+    t.string "club"
     t.string "county"
+    t.datetime "created_at", null: false
+    t.integer "distance"
+    t.integer "heat"
+    t.string "name"
+    t.integer "person_id"
+    t.integer "position"
+    t.integer "race_id", null: false
+    t.string "result"
+    t.decimal "seconds"
+    t.datetime "updated_at", null: false
     t.index ["person_id"], name: "index_results_on_person_id"
     t.index ["race_id"], name: "index_results_on_race_id"
   end
 
   create_table "sessions", force: :cascade do |t|
-    t.string "user_agent"
-    t.string "ip_address"
-    t.string "token", null: false
-    t.datetime "last_active_at", null: false
-    t.integer "user_id"
     t.datetime "created_at", null: false
+    t.string "ip_address"
+    t.datetime "last_active_at", null: false
+    t.string "token", null: false
     t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.integer "user_id"
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
   create_table "teams", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.string "name"
     t.string "slug"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "thredded_categories", force: :cascade do |t|
+    t.datetime "created_at", precision: nil, null: false
+    t.text "description"
     t.integer "messageboard_id", null: false
     t.text "name", null: false
-    t.text "description"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.text "slug", null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["messageboard_id", "slug"], name: "index_thredded_categories_on_messageboard_id_and_slug", unique: true
     t.index ["messageboard_id"], name: "index_thredded_categories_on_messageboard_id"
     t.index ["name"], name: "thredded_categories_name_ci"
   end
 
   create_table "thredded_messageboard_groups", force: :cascade do |t|
+    t.datetime "created_at", precision: nil, null: false
     t.string "name"
     t.integer "position", null: false
-    t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "thredded_messageboard_notifications_for_followed_topics", force: :cascade do |t|
-    t.integer "user_id", null: false
+    t.boolean "enabled", default: true, null: false
     t.integer "messageboard_id", null: false
     t.string "notifier_key", limit: 90, null: false
-    t.boolean "enabled", default: true, null: false
+    t.integer "user_id", null: false
     t.index ["user_id", "messageboard_id", "notifier_key"], name: "thredded_messageboard_notifications_for_followed_topics_unique", unique: true
   end
 
   create_table "thredded_messageboard_users", force: :cascade do |t|
-    t.integer "thredded_user_detail_id", null: false
-    t.integer "thredded_messageboard_id", null: false
     t.datetime "last_seen_at", precision: nil, null: false
+    t.integer "thredded_messageboard_id", null: false
+    t.integer "thredded_user_detail_id", null: false
     t.index ["thredded_messageboard_id", "last_seen_at"], name: "index_thredded_messageboard_users_for_recently_active"
     t.index ["thredded_messageboard_id", "thredded_user_detail_id"], name: "index_thredded_messageboard_users_primary", unique: true
   end
 
   create_table "thredded_messageboards", force: :cascade do |t|
-    t.text "name", null: false
-    t.text "slug"
-    t.text "description"
-    t.integer "topics_count", default: 0
-    t.integer "posts_count", default: 0
-    t.integer "position", null: false
-    t.integer "last_topic_id"
-    t.integer "messageboard_group_id"
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.text "description"
+    t.integer "last_topic_id"
     t.boolean "locked", default: false, null: false
+    t.integer "messageboard_group_id"
+    t.text "name", null: false
+    t.integer "position", null: false
+    t.integer "posts_count", default: 0
+    t.text "slug"
+    t.integer "topics_count", default: 0
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["messageboard_group_id"], name: "index_thredded_messageboards_on_messageboard_group_id"
     t.index ["slug"], name: "index_thredded_messageboards_on_slug", unique: true
   end
 
   create_table "thredded_notifications_for_followed_topics", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "notifier_key", limit: 90, null: false
     t.boolean "enabled", default: true, null: false
+    t.string "notifier_key", limit: 90, null: false
+    t.integer "user_id", null: false
     t.index ["user_id", "notifier_key"], name: "thredded_notifications_for_followed_topics_unique", unique: true
   end
 
   create_table "thredded_notifications_for_private_topics", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "notifier_key", limit: 90, null: false
     t.boolean "enabled", default: true, null: false
+    t.string "notifier_key", limit: 90, null: false
+    t.integer "user_id", null: false
     t.index ["user_id", "notifier_key"], name: "thredded_notifications_for_private_topics_unique", unique: true
   end
 
   create_table "thredded_post_moderation_records", force: :cascade do |t|
-    t.integer "post_id"
+    t.datetime "created_at", precision: nil, null: false
     t.integer "messageboard_id"
+    t.integer "moderation_state", null: false
+    t.integer "moderator_id"
     t.text "post_content", limit: 65535
+    t.integer "post_id"
     t.integer "post_user_id"
     t.text "post_user_name"
-    t.integer "moderator_id"
-    t.integer "moderation_state", null: false
     t.integer "previous_moderation_state", null: false
-    t.datetime "created_at", precision: nil, null: false
     t.index ["messageboard_id", "created_at"], name: "index_thredded_moderation_records_for_display", order: { created_at: :desc }
   end
 
   create_table "thredded_posts", force: :cascade do |t|
-    t.integer "user_id"
     t.text "content", limit: 65535
-    t.string "source", limit: 191, default: "web"
-    t.integer "postable_id", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.integer "messageboard_id", null: false
     t.integer "moderation_state", null: false
-    t.datetime "created_at", precision: nil, null: false
+    t.integer "postable_id", null: false
+    t.string "source", limit: 191, default: "web"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id"
     t.index ["messageboard_id"], name: "index_thredded_posts_on_messageboard_id"
     t.index ["moderation_state", "updated_at"], name: "index_thredded_posts_for_display"
     t.index ["postable_id", "created_at"], name: "index_thredded_posts_on_postable_id_and_created_at"
@@ -295,59 +305,59 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_19_213139) do
   end
 
   create_table "thredded_private_posts", force: :cascade do |t|
-    t.integer "user_id"
     t.text "content", limit: 65535
-    t.integer "postable_id", null: false
     t.datetime "created_at", precision: nil, null: false
+    t.integer "postable_id", null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id"
     t.index ["postable_id", "created_at"], name: "index_thredded_private_posts_on_postable_id_and_created_at"
   end
 
   create_table "thredded_private_topics", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "last_user_id"
-    t.text "title", null: false
-    t.text "slug", null: false
-    t.integer "posts_count", default: 0
+    t.datetime "created_at", precision: nil, null: false
     t.string "hash_id", limit: 20, null: false
     t.datetime "last_post_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
+    t.integer "last_user_id"
+    t.integer "posts_count", default: 0
+    t.text "slug", null: false
+    t.text "title", null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id"
     t.index ["hash_id"], name: "index_thredded_private_topics_on_hash_id"
     t.index ["last_post_at"], name: "index_thredded_private_topics_on_last_post_at"
     t.index ["slug"], name: "index_thredded_private_topics_on_slug", unique: true
   end
 
   create_table "thredded_private_users", force: :cascade do |t|
-    t.integer "private_topic_id"
-    t.integer "user_id"
     t.datetime "created_at", precision: nil, null: false
+    t.integer "private_topic_id"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id"
     t.index ["private_topic_id"], name: "index_thredded_private_users_on_private_topic_id"
     t.index ["user_id"], name: "index_thredded_private_users_on_user_id"
   end
 
   create_table "thredded_topic_categories", force: :cascade do |t|
-    t.integer "topic_id", null: false
     t.integer "category_id", null: false
+    t.integer "topic_id", null: false
     t.index ["category_id"], name: "index_thredded_topic_categories_on_category_id"
     t.index ["topic_id"], name: "index_thredded_topic_categories_on_topic_id"
   end
 
   create_table "thredded_topics", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "last_user_id"
-    t.text "title", null: false
-    t.text "slug", null: false
-    t.integer "messageboard_id", null: false
-    t.integer "posts_count", default: 0, null: false
-    t.boolean "sticky", default: false, null: false
-    t.boolean "locked", default: false, null: false
-    t.string "hash_id", limit: 20, null: false
-    t.integer "moderation_state", null: false
-    t.datetime "last_post_at", precision: nil
     t.datetime "created_at", precision: nil, null: false
+    t.string "hash_id", limit: 20, null: false
+    t.datetime "last_post_at", precision: nil
+    t.integer "last_user_id"
+    t.boolean "locked", default: false, null: false
+    t.integer "messageboard_id", null: false
+    t.integer "moderation_state", null: false
+    t.integer "posts_count", default: 0, null: false
+    t.text "slug", null: false
+    t.boolean "sticky", default: false, null: false
+    t.text "title", null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id"
     t.index ["hash_id"], name: "index_thredded_topics_on_hash_id"
     t.index ["last_post_at"], name: "index_thredded_topics_on_last_post_at"
     t.index ["messageboard_id"], name: "index_thredded_topics_on_messageboard_id"
@@ -357,116 +367,116 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_19_213139) do
   end
 
   create_table "thredded_user_details", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.datetime "latest_activity_at", precision: nil
-    t.integer "posts_count", default: 0
-    t.integer "topics_count", default: 0
+    t.datetime "created_at", precision: nil, null: false
     t.datetime "last_seen_at", precision: nil
+    t.datetime "latest_activity_at", precision: nil
     t.integer "moderation_state", default: 0, null: false
     t.datetime "moderation_state_changed_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
+    t.integer "posts_count", default: 0
+    t.integer "topics_count", default: 0
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id", null: false
     t.index ["latest_activity_at"], name: "index_thredded_user_details_on_latest_activity_at"
     t.index ["moderation_state", "moderation_state_changed_at"], name: "index_thredded_user_details_for_moderations", order: { moderation_state_changed_at: :desc }
     t.index ["user_id"], name: "index_thredded_user_details_on_user_id", unique: true
   end
 
   create_table "thredded_user_messageboard_preferences", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "messageboard_id", null: false
-    t.boolean "follow_topics_on_mention", default: true, null: false
     t.boolean "auto_follow_topics", default: false, null: false
     t.datetime "created_at", precision: nil, null: false
+    t.boolean "follow_topics_on_mention", default: true, null: false
+    t.integer "messageboard_id", null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id", null: false
     t.index ["user_id", "messageboard_id"], name: "thredded_user_messageboard_preferences_user_id_messageboard_id", unique: true
   end
 
   create_table "thredded_user_post_notifications", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "post_id", null: false
     t.datetime "notified_at", precision: nil, null: false
+    t.integer "post_id", null: false
+    t.integer "user_id", null: false
     t.index ["post_id"], name: "index_thredded_user_post_notifications_on_post_id"
     t.index ["user_id", "post_id"], name: "index_thredded_user_post_notifications_on_user_id_and_post_id", unique: true
   end
 
   create_table "thredded_user_preferences", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.boolean "follow_topics_on_mention", default: true, null: false
     t.boolean "auto_follow_topics", default: false, null: false
     t.datetime "created_at", precision: nil, null: false
+    t.boolean "follow_topics_on_mention", default: true, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id", null: false
     t.index ["user_id"], name: "index_thredded_user_preferences_on_user_id", unique: true
   end
 
   create_table "thredded_user_private_topic_read_states", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "postable_id", null: false
-    t.integer "unread_posts_count", default: 0, null: false
-    t.integer "read_posts_count", default: 0, null: false
     t.integer "integer", default: 0, null: false
+    t.integer "postable_id", null: false
     t.datetime "read_at", precision: nil, null: false
+    t.integer "read_posts_count", default: 0, null: false
+    t.integer "unread_posts_count", default: 0, null: false
+    t.integer "user_id", null: false
     t.index ["user_id", "postable_id"], name: "thredded_user_private_topic_read_states_user_postable", unique: true
   end
 
   create_table "thredded_user_topic_follows", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "topic_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.integer "reason", limit: 1
+    t.integer "topic_id", null: false
+    t.integer "user_id", null: false
     t.index ["user_id", "topic_id"], name: "thredded_user_topic_follows_user_topic", unique: true
   end
 
   create_table "thredded_user_topic_read_states", force: :cascade do |t|
-    t.integer "messageboard_id", null: false
-    t.integer "user_id", null: false
-    t.integer "postable_id", null: false
-    t.integer "unread_posts_count", default: 0, null: false
-    t.integer "read_posts_count", default: 0, null: false
     t.integer "integer", default: 0, null: false
+    t.integer "messageboard_id", null: false
+    t.integer "postable_id", null: false
     t.datetime "read_at", precision: nil, null: false
+    t.integer "read_posts_count", default: 0, null: false
+    t.integer "unread_posts_count", default: 0, null: false
+    t.integer "user_id", null: false
     t.index ["messageboard_id"], name: "index_thredded_user_topic_read_states_on_messageboard_id"
     t.index ["user_id", "messageboard_id"], name: "thredded_user_topic_read_states_user_messageboard"
     t.index ["user_id", "postable_id"], name: "thredded_user_topic_read_states_user_postable", unique: true
   end
 
   create_table "time_trials", force: :cascade do |t|
-    t.integer "distance"
-    t.string "surface"
-    t.date "recorded_at", null: false
     t.datetime "created_at", null: false
+    t.integer "distance"
+    t.date "recorded_at", null: false
+    t.string "surface"
     t.datetime "updated_at", null: false
   end
 
   create_table "topics", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "forum_id"
     t.string "name", limit: 256, null: false
     t.string "slug", limit: 256, null: false
-    t.integer "forum_id"
-    t.integer "user_id"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
     t.index ["forum_id"], name: "index_topics_on_forum_id"
     t.index ["user_id"], name: "index_topics_on_user_id"
   end
 
   create_table "tt_times", force: :cascade do |t|
-    t.decimal "seconds"
-    t.integer "person_id", null: false
-    t.integer "time_trial_id", null: false
     t.datetime "created_at", null: false
+    t.integer "person_id", null: false
+    t.decimal "seconds"
+    t.integer "time_trial_id", null: false
     t.datetime "updated_at", null: false
     t.index ["person_id"], name: "index_tt_times_on_person_id"
     t.index ["time_trial_id"], name: "index_tt_times_on_time_trial_id"
   end
 
   create_table "users", force: :cascade do |t|
+    t.boolean "admin", default: false, null: false
+    t.datetime "created_at", null: false
     t.string "email", null: false
     t.string "encrypted_password", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "admin", default: false, null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at"
+    t.string "reset_password_token"
+    t.datetime "updated_at", null: false
     t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -474,6 +484,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_19_213139) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "coach_posts", "users"
   add_foreign_key "memberships", "people"
   add_foreign_key "memberships", "teams"
   add_foreign_key "messages", "messages", column: "parent_id"


### PR DESCRIPTION
I'm going to add the [friendly_id gem](https://github.com/norman/friendly_id) in a future update, so getting the database tables in here now.

Also adding in tables for coach_posts, to allow coaches to post information for other coaches