### PR TITLE
Truncate news posts on the front page

### DIFF
--- a/app/views/site/index.html.erb
+++ b/app/views/site/index.html.erb
@@ -15,7 +15,14 @@
       <div class="card-body">
         <h2 class="card-title"><%= link_to post.title, post_path(post) %></h2>
         <div class="card-subtitle mb-2 text-body-tertiary"><%= post.created_at.strftime("%b %-d, %Y") %></div>
-        <span class="card-text"><%= post.content %></span>
+        <span class="card-text">
+          <%- if Castlebarac.truncate_post?(current_user) %>
+            <%= post.content.to_plain_text.truncate(150) %>
+            <br /><%= link_to "Read more", post_path(post) %>
+          <%- else %>
+            <%= post.content %>
+          <%- end %>
+        </span>
       </div>
     </article>
   <%- end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,4 +34,8 @@ module Castlebarac
   def self.show_about?(user = nil)
     Flipper.enabled?(:about, user)
   end
+
+  def self.truncate_post?(user = nil)
+    Flipper.enabled?(:truncate_post, user)
+  end
 end


### PR DESCRIPTION
Only truncating the plain text and offering a read more link. Hidden behind a feature flag